### PR TITLE
Put gtk the first in PATH environment variable (fixed the issues of running the tool on some windows environments)

### DIFF
--- a/build-on-windows.ps1
+++ b/build-on-windows.ps1
@@ -33,8 +33,8 @@ Remove-Item "$workingDir/python.tar.gz" -Recurse -Force | Out-Null
 
 Set-Location  "$workingDir/python"
 Write-Host "*** Installing $version"
+$Env:PATH = "$workingDir/gtk3;$Env:PATH"
 Invoke-Expression ".\python.exe -m pip install $version"
-$Env:PATH += ";$workingDir/gtk3"
 Write-Host "*** Testing weasyprint"
 Invoke-Expression ".\python.exe -m weasyprint --info"
 New-Item -Path "$workingDir/version-$version"

--- a/src/Weasyprint.Wrapped/Printer.cs
+++ b/src/Weasyprint.Wrapped/Printer.cs
@@ -78,7 +78,7 @@ public class Printer
             command = Cli
                 .Wrap($"{workingFolder}/python/python.exe")
                 .WithWorkingDirectory($"{workingFolder}/python")
-                .WithEnvironmentVariables(env => env.Set("PATH", $"{Environment.GetEnvironmentVariable("PATH")};{new FileInfo($"{workingFolder}/gtk3").FullName}"));
+                .WithEnvironmentVariables(env => env.Set("PATH", $"{new FileInfo($"{workingFolder}/gtk3").FullName};{Environment.GetEnvironmentVariable("PATH")}"));
         }
         else
         {


### PR DESCRIPTION
related to https://github.com/berthertogen/weasyprint.wrapped/issues/32