### PR TITLE
Allow to pass CancelationToken to Printer.Print method, which allows to specify a printing timeout.

### DIFF
--- a/src/Weasyprint.Wrapped/Printer.cs
+++ b/src/Weasyprint.Wrapped/Printer.cs
@@ -51,6 +51,11 @@ public class Printer
         }
     }
 
+    public async Task<PrintResult> Print(string html)
+    {
+        return await Print(html, cancellationToken: default);
+    }
+
     public async Task<PrintResult> Print(string html, CancellationToken cancellationToken = default)
     {
         using var outputStream = new MemoryStream();

--- a/src/Weasyprint.Wrapped/Printer.cs
+++ b/src/Weasyprint.Wrapped/Printer.cs
@@ -51,7 +51,7 @@ public class Printer
         }
     }
 
-    public async Task<PrintResult> Print(string html)
+    public async Task<PrintResult> Print(string html, CancellationToken cancellationToken = default)
     {
         using var outputStream = new MemoryStream();
         var stdErrBuffer = new StringBuilder();
@@ -61,7 +61,7 @@ public class Printer
             .WithStandardInputPipe(PipeSource.FromString(html, Encoding.UTF8))
             .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErrBuffer))
             .WithValidation(CommandResultValidation.None)
-            .ExecuteBufferedAsync(Encoding.UTF8);
+            .ExecuteBufferedAsync(Encoding.UTF8, cancellationToken);
         return new PrintResult(
             outputStream.ToArray(),
             stdErrBuffer.ToString(),


### PR DESCRIPTION
It could be helpful having a timeout or the ability to cancel printing pdf, in case it's too long or stuck.