### PR TITLE
baseUrl option for ConfigurationProvider added

### DIFF
--- a/src/Weasyprint.Wrapped/Configuration/ConfigurationProvider.cs
+++ b/src/Weasyprint.Wrapped/Configuration/ConfigurationProvider.cs
@@ -5,6 +5,7 @@ public class ConfigurationProvider
 {
     protected readonly string assetsFolder;
     protected readonly string workingFolder;
+    private string baseUrl = ".";
 
     public ConfigurationProvider() : this(string.Empty, false, "weasyprinter", false) { }
 
@@ -27,4 +28,12 @@ public class ConfigurationProvider
 
     public string GetWorkingFolder()
         => workingFolder;
+
+    public void SetBaseUrl(string baseUrl)
+    {
+        this.baseUrl = baseUrl;
+    }
+
+    public string GetBaseUrl()
+        => baseUrl;
 }

--- a/src/Weasyprint.Wrapped/Printer.cs
+++ b/src/Weasyprint.Wrapped/Printer.cs
@@ -9,6 +9,7 @@ public class Printer
 {
     private readonly string workingFolder;
     private readonly string asset;
+    private readonly string baseUrl;
 
     public Printer() : this(new ConfigurationProvider()) { }
 
@@ -16,6 +17,7 @@ public class Printer
     {
         workingFolder = configurationProvider.GetWorkingFolder();
         asset = configurationProvider.GetAsset();
+        baseUrl = configurationProvider.GetBaseUrl();
     }
 
     public async Task Initialize()
@@ -61,7 +63,7 @@ public class Printer
         using var outputStream = new MemoryStream();
         var stdErrBuffer = new StringBuilder();
         var result = await BuildOsSpecificCommand()
-            .WithArguments($"-m weasyprint - - --encoding utf8")
+            .WithArguments($"-m weasyprint - - --encoding utf8 --base-url {baseUrl}")
             .WithStandardOutputPipe(PipeTarget.ToStream(outputStream))
             .WithStandardInputPipe(PipeSource.FromString(html, Encoding.UTF8))
             .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErrBuffer))


### PR DESCRIPTION
Possibility to set baseUrl (https://doc.courtbouillon.org/weasyprint/stable/api_reference.html#cmdoption-u). By default, it sets "." so no intervention with the previous behavior. It helps to locate static assets in Blazor, like fetcing .css files and images