### PR TITLE
Allows to call weasyprint with file paths

### DIFF
--- a/src/Weasyprint.Wrapped/Printer.cs
+++ b/src/Weasyprint.Wrapped/Printer.cs
@@ -88,6 +88,29 @@ public class Printer
         );
     }
 
+    /// <summary>
+    /// Prints the given html to pdf using the weasyprint library.
+    /// </summary>
+    /// <param name="htmlFile">html file name with path to be converted to pdf</param>
+    /// <param name="pdfFile">pdf file name with path for output</param>
+    /// <param name="cancellationToken">Optional cancellationToken, passed to the executing command</param>
+    /// <param name="additionalParameters">list of additional parameter for weasyprint (see readme.md#Weasyprint-CLI)</param>
+    public async Task<PrintResult> Print(string htmlFile, string pdfFile, CancellationToken cancellationToken = default, params string[] additionalParameters)
+    {
+        var stdErrBuffer = new StringBuilder();
+        var result = await BuildOsSpecificCommand()
+            .WithArguments($"-m weasyprint --encoding utf8 --base-url {baseUrl} {string.Join(" ", additionalParameters)} {htmlFile} {pdfFile}")
+            .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErrBuffer))
+            .WithValidation(CommandResultValidation.None)
+            .ExecuteBufferedAsync(Encoding.UTF8, cancellationToken);
+        return new PrintResult(
+            Array.Empty<byte>(),
+            stdErrBuffer.ToString(),
+            result.RunTime,
+            result.ExitCode
+        );
+    }    
+    
     private Command BuildOsSpecificCommand()
     {
         Command command;


### PR DESCRIPTION
Using your wrapper we phased with strange hangs on Linux. It happened even with small 1 page files with few lines of text. We was not able to find the reason of it but passing input\output through files helps.
P.S. I tried to add tests, but they was not working properly: result.Error contains warnings from output. Could be my machine specific. I think some generic things to handle it correctly can be implemented. But it out of the scope the current issue.
![image](https://github.com/berthertogen/weasyprint.wrapped/assets/4746860/2c43e530-932b-4545-a922-8956cf32c393)
