### PR TITLE
Disposing ZipArchive

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,10 +35,10 @@ await new Printer().Print("<html><body><h1>TEST</h1></body></html>");
 
 ## Warning
 
-This is a large package, try to limit the projects where it will be installed.
+There are resources which will be extracted during initialization, the size of it is:
 
-- +-104 MB zipped resource (standalone python, gtk3 for windows and weasyprint) which will be unzipped on initialization in the same folder (for windows).
-- +-89.7 MB zipped resource (standalone python and weasyprint) which will be unzipped on initialization in the same folder (for linux).
+- +-29 MB zipped resource (official standalone windows executable) which will be unzipped in the same folder (for Windows).
+- +-26 MB zipped resource (standalone build weasyprint) which will be unzipped in the same folder (for Linux).
 
 # Extra resources
 
@@ -128,7 +128,7 @@ Windows:
 .\build-on-windows.ps1
 ```
 
-Linux:
+Linux (docker is needed):
 
 ```
 .\build-on-linux.ps1
@@ -145,7 +145,7 @@ Update the example project package version (Weasyprint.Wrapped.Example.csproj) a
 
 ## Error in tests
 
-The following error might be thrown when running the tests on windows:
+The following error might be thrown when running the tests on Windows:
 
 ``` shell
 (process:13448): GLib-GIO-WARNING **: 17:21:45.816: Unexpectedly, UWP app `Microsoft.OutlookForWindows_1.2023.1114.100_x64__8wekyb3d8bbwe' (AUMId `Microsoft.OutlookForWindows_8wekyb3d8bbwe!Microsoft.OutlookforWindows') supports 1 extensions but has no verbs
@@ -157,35 +157,18 @@ Check here for the answer: <https://stackoverflow.com/questions/67607643/what-do
 
 ### Windows (build-on-windows.ps1 does approximately this)
 
-* Download https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/releases and install to C:\weasyprint.wrapped\standalone-win-64\gtk
-* Download https://github.com/indygreg/python-build-standalone/releases (correct release, eg: cpython-3.10.4+20220502-x86_64-pc-windows-msvc-shared-install_only.tar.gz for windows) and extract to c:
-  \weasyprint.wrapped\standalone-win-64\python
-* Add gtk3 to path (in current session)
-
-``` powershell
-$Env:PATH += ";C:\weasyprint.wrapped\standalone-win-64\gtk3\bin"
-```
-
-* Install weasyprint in the standalone python
-
-```
-cd c:\weasyprint.wrapped\standalone-win-64\python
-.\python.exe -m pip install weasyprint
-.\python.exe -m weasyprint --info
-```
+* Download the Windows standalone binary https://github.com/Kozea/WeasyPrint/releases
+* Pack it into the resources zip for Windows
 
 ### Linux (build-on-linux.ps1 does approximately this)
 
-* Install powershell on ubuntu (https://docs.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7.2)
-* Download https://github.com/indygreg/python-build-standalone/releases (correct release, eg: cpython-3.10.4+20220502-x86_64-unknown-linux-gnu-install_only.tar.gz for Linux) and extract to c:
-  \weasyprint.wrapped\standalone-linux-64\python
-* Install weasyprint in the standalone python
-
-```
-cd c:\weasyprint.wrapped\standalone-linux-64\python\bin\
-python3 -m pip install weasyprint
-python3 -m weasyprint --info
-```
+* Starting a docker image with an Ubunut 22.04
+* Update the image to the latest packages
+* Installing python3 and all the dependencies for weasyprint inside the docker image
+* Install weasyprint and pyinstaller using pip
+* Use pyinstaller to create a standalone executable for Linux (https://pyinstaller.org/en/stable/usage.html#creating-a-one-file-bundle)
+* Chek the newly created executable in a new clean docker image to make sure it works and has all the needed dependencies
+* Pack the executable into the resources zip for Linux
 
 ### Help
 

--- a/src/Weasyprint.Wrapped/Printer.cs
+++ b/src/Weasyprint.Wrapped/Printer.cs
@@ -26,7 +26,8 @@ public class Printer
 
     public async Task Initialize()
     {
-        var version = ZipFile.OpenRead(asset).Entries.Single(e => e.Name.StartsWith("version-")).Name;
+        using var zipArchive = ZipFile.OpenRead(asset);
+        var version = zipArchive.Entries.Single(e => e.Name.StartsWith("version-")).Name;
         if (File.Exists(Path.Combine(workingFolder, version))) return;
 
         if (Directory.Exists(workingFolder)) Directory.Delete(workingFolder, true);


### PR DESCRIPTION
The initialization method lacks to dispose the ZipArchive which will be created during ZipFile.OpenRead. I added an using statement to make sure that this ZipArchive will be disposed afterwards.

Furthermore I have adjusted the README to the latest changes of the scripts, so it's not outdated anymore.